### PR TITLE
Use only BERT-like models needed for UDPipe 2.10

### DIFF
--- a/wembedding/Dockerfile
+++ b/wembedding/Dockerfile
@@ -9,7 +9,6 @@ FROM tensorflow/tensorflow:2.3.1-gpu
 WORKDIR /wembedding_service
 COPY --from=builder /wembedding_service .
 RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install sentencepiece
 RUN python start_wembeddings_server.py 8000 --preload_models bert-base-multilingual-uncased-last4 robeczech-base-last4 --preload_only
 
 EXPOSE 8000

--- a/wembedding/Dockerfile
+++ b/wembedding/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /wembedding_service
 COPY --from=builder /wembedding_service .
 RUN pip install --no-cache-dir -r requirements.txt
 RUN pip install sentencepiece
-RUN python start_wembeddings_server.py 8000 --preload_models=all --preload_only
+RUN python start_wembeddings_server.py 8000 --preload_models bert-base-multilingual-uncased-last4 robeczech-base-last4 --preload_only
 
 EXPOSE 8000
 ENTRYPOINT ["python", "start_wembeddings_server.py", "8000"]


### PR DESCRIPTION
With `all`, XLM-RoBERTA base with ~1.9GB was unnecessarily used.